### PR TITLE
Fix: Increase minimum wallet top up amount to 50

### DIFF
--- a/src/lib/schemas.js
+++ b/src/lib/schemas.js
@@ -29,7 +29,7 @@ export const TopUpAccountSchema = type({
 
 export const TopUpAccountDefaults = {
   payment_method: null,
-  amount: 20,
+  amount: 50,
 };
 
 export const VoucherCodeSchema = type({

--- a/src/routes/(app)/user/wallet/[[cursor]]/Wallet.svelte
+++ b/src/routes/(app)/user/wallet/[[cursor]]/Wallet.svelte
@@ -20,7 +20,7 @@
     timeoutMs: 8000,
   });
 
-  $: minAmount = Math.ceil((currencies[$form.payment_method]?.min_amount || 0) / 10) * 10;
+  $: minAmount = Math.max(Math.ceil((currencies[$form.payment_method]?.min_amount || 0) / 10) * 10, 50);
 </script>
 
 {#if $message}


### PR DESCRIPTION
The charges are to high for the crypto transactions when the amounts are belo $50. So let's have the minimum wallet top up balance be $50 for better end-user charges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated default top-up amount from 20 to 50.
	- Ensured a minimum top-up amount of 50 when using the wallet feature.

- **Bug Fixes**
	- Improved calculation logic for minimum amount in the wallet component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->